### PR TITLE
Fix for IE 11 context bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var raf = require('raf-component')
 var ease = require('ease-component')
+raf.bind(window)
 
 function scroll (prop, element, to, options, callback) {
   var start = +new Date


### PR DESCRIPTION
Fixes IE "SCRIPT5002: Function expected" error.

If the requestAnimationFrame object is not bound to window, IE freaks.