### PR TITLE
Updated usage for IE compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var raf = require('raf-component')
 var ease = require('ease-component')
+raf.bind(window)
 
 function scroll (prop, element, to, options, callback) {
   var start = +new Date

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,9 @@ npm install scroll
 ### Usage
 ``` js
 var scroll = require('scroll')
+var scrollDoc = require('scroll-doc')
 
-var page = /Firefox/.test(navigator.userAgent) ?
-  document.documentElement :
-  document.body
+var page = scrollDoc()
 
 // Basic usage
 scroll.left(page, 200)


### PR DESCRIPTION
As is, the documented usage fails in IE, as it doesn't use `document.body` for scrolling.