### PR TITLE
using Date.now for getting current time

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var E_NOSCROLL = new Error('Element already at target scroll position')
 var E_CANCELLED = new Error('Scroll cancelled')
 var min = Math.min
+var now = Date.now
 
 module.exports = {
   left: make('scrollLeft'),
@@ -14,7 +15,7 @@ function make (prop) {
     if (typeof opts == 'function') cb = opts, opts = {}
     if (typeof cb != 'function') cb = noop
 
-    var start = +new Date
+    var start = now()
     var from = el[prop]
     var ease = opts.ease || inOutSine
     var duration = !isNaN(opts.duration) ? +opts.duration : 350


### PR DESCRIPTION
As of https://jsperf.com/date-now-vs-new-date it is more performant to use `Date.now` instead of `+new Date`. Since animations can be expensive I think it makes sense to aim for the best performance. The function also has very broad support across browsers (see [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/now#Browser_compatibility)).

Thanks for this lib! 😄 